### PR TITLE
[Docs] Correcting usage of installAll build target

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Please note for this to work you should create/update `~/.gradle/gradle.properti
     signing.secretKeyRingFile=
 
 ### Installing the jars to the local Maven repository ###
-    ./gradlew installAll
+    ./gradlew install
 
 ### Building the test jar ###
     ./gradlew testJar


### PR DESCRIPTION
Using 'installAll' gives the following error:
Using Task 'installAll' not found in root project 'kafka'. Some candidates are: 'install'.
